### PR TITLE
Adding greater ubuntu support & adding clarity to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Shell script to install a [Dividend.Cash Masternode](https://dividend.cash/) on 
 ***
 ## Installation:
 ```
-bash <(curl -s https://raw.githubusercontent.com/dividendcash/masternodeinstall/master/dvd.sh)
+wget https://raw.githubusercontent.com/dividendcash/masternodeinstall/master/dvd.sh
+sudo chmod +x dvd.sh && sudo bash dvd.sh
 ```
 ***
 
@@ -19,9 +20,19 @@ After the MN is up and running, you need to configure the desktop wallet accordi
 6. Type the following command: **masternode outputs**
 7. Go to  ** Tools -> "Open Masternode Configuration File"
 8. Add the following entry:
+
 ```
 Alias Address Privkey TxHash Output_index
 ```
+
+Your entry should look something similar to this --
+
+```
+MN1 0.0.0.0:19997 88ET491cBrrZaKoCKyTdjvZStvM97iB102HS82AJDwFEE1jgP AZ30b9a06a54030315ea8110ab2670808946bc3a3640e1010292909343f876 0
+
+```
+
+
 * Alias: **MN1**
 * Address: **VPS_IP:PORT**
 * Privkey: **Masternode Private Key**

--- a/dvd.sh
+++ b/dvd.sh
@@ -229,9 +229,11 @@ fi
 }
 
 function detect_ubuntu() {
- if [[ $(lsb_release -d) == *16.04* ]]; then
+ if [[ $(lsb_release -d) == *18.* ]]; then
+   UBUNTU_VERSION=18
+ elif [[ $(lsb_release -d) == *16.* ]]; then
    UBUNTU_VERSION=16
- elif [[ $(lsb_release -d) == *14.04* ]]; then
+ elif [[ $(lsb_release -d) == *14.* ]]; then
    UBUNTU_VERSION=14
 else
    echo -e "${RED}You are not running Ubuntu 14.04 or 16.04 Installation is cancelled.${NC}"
@@ -250,12 +252,13 @@ if [ -n "$(pidof $COIN_DAEMON)" ] || [ -e "$COIN_DAEMOM" ] ; then
   echo -e "${RED}$COIN_NAME is already installed.${NC}"
   exit 1
 fi
+
 }
 
 function prepare_system() {
 echo -e "Prepare the system to install ${GREEN}$COIN_NAME${NC} master node."
 apt-get update >/dev/null 2>&1
-apt-get install -y wget curl binutils >/dev/null 2>&1
+apt-get install -y wget curl binutils net-tools >/dev/null 2>&1
 }
 
 function important_information() {
@@ -263,7 +266,11 @@ function important_information() {
  echo -e "================================================================================"
  echo -e "$COIN_NAME Masternode is up and running listening on port ${RED}$COIN_PORT${NC}."
  echo -e "Configuration file is: ${RED}$CONFIGFOLDER/$CONFIG_FILE${NC}"
- if (( $UBUNTU_VERSION == 16 )); then
+ if (( $UBUNTU_VERSION == 18 )); then
+   echo -e "Start: ${RED}service $COIN_NAME start${NC}"
+   echo -e "Stop: ${RED}service $COIN_NAME stop${NC}"
+   echo -e "Status: ${RED}service $COIN_NAME status${NC}"
+ elif (( $UBUNTU_VERSION == 16 )); then
    echo -e "Start: ${RED}systemctl start $COIN_NAME.service${NC}"
    echo -e "Stop: ${RED}systemctl stop $COIN_NAME.service${NC}"
    echo -e "Status: ${RED}systemctl status $COIN_NAME.service${NC}"
@@ -289,7 +296,7 @@ function setup_node() {
   update_config
   enable_firewall
   important_information
-  if (( $UBUNTU_VERSION == 16 )); then
+  if (( $UBUNTU_VERSION == 16 ) || ($UBUNTU_VERSION == 18)); then
     configure_systemd
   else
     configure_startup


### PR DESCRIPTION
- Updates `dvd.sh` to install `net-tools` as it is currently assumed to be installed.
- Added conditionals for Ubuntu 18.
- Updated `README.md` with instructions that will work on any of the major releases supported.
- Updated `README.md` to add a masternode configuration example as was unclear having only included field names.